### PR TITLE
Ignore logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ __pycache__
 
 .idea/
 credentials/
+logging/
 *.db

--- a/logging/2020-10-15 22:54:02.311371.txt
+++ b/logging/2020-10-15 22:54:02.311371.txt
@@ -1,1 +1,0 @@
-HTTPConnectionPool(host='localhost', port=7998): Max retries exceeded with url: //embedded/v1/vehicles/%7B1231%7D (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f3f5d3506a0>: Failed to establish a new connection: [Errno 111] Connection refused',))

--- a/services/function_helper.py
+++ b/services/function_helper.py
@@ -90,6 +90,8 @@ def sendToVCar(gathered_information, endpoint):
     
 
 def logError(string_val):
+    if not os.path.exists("logging"):
+        os.system("mkdir logging")
     
     print("Error!: " + str(string_val))
 


### PR DESCRIPTION
### What are you trying to do?
Ignore the logging folder from GitHub

### How are you doing it?
The logging folder is removed, and its path added to the gitignore. The function_helper expected the folder to always be there and it is no longer a part of the GitHub repo; rather than expect the user to create the folder, the function checks if it exists and creates the folder if it does not.

### Is there anything reviewers should know?

